### PR TITLE
Add HTML export example

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,19 @@ script for calculating "hits" based on simple trading rules.
 September 2024 until July 2025. Each row has `Time`, `Open`, `High`, `Low` and
 `Close` columns.
 
+## Script: `create_sample_html.py`
+
+`create_sample_html.py` loads the CSV with pandas and outputs a small HTML
+file containing the first 50 rows as a candlestick chart and a data table.
+
+Run the script with:
+
+```bash
+python3 create_sample_html.py
+```
+
+It generates `sample_candles.html` in the repository directory.
+
 ## Script: `compute_hits.py`
 
 The `compute_hits.py` script reads the CSV file and applies a basic trading

--- a/create_sample_html.py
+++ b/create_sample_html.py
@@ -1,0 +1,50 @@
+import pandas as pd
+import numpy as np
+import plotly.graph_objects as go
+
+SAMPLE_SIZE = 50
+CSV_FILE = "EURUSD_M30_Data.csv"
+
+
+def main() -> None:
+    df = pd.read_csv(CSV_FILE)
+    df["Time"] = pd.to_datetime(df["Time"])
+    sample = df.head(SAMPLE_SIZE)
+
+    fig = go.Figure(
+        data=[
+            go.Candlestick(
+                x=sample["Time"],
+                open=sample["Open"],
+                high=sample["High"],
+                low=sample["Low"],
+                close=sample["Close"],
+            )
+        ]
+    )
+    fig.update_layout(title=f"First {SAMPLE_SIZE} EURUSD 30m bars")
+    chart_html = fig.to_html(full_html=False, include_plotlyjs="cdn")
+    table_html = sample.to_html(index=False)
+
+    html = f"""<!DOCTYPE html>
+<html>
+<head>
+    <meta charset=\"utf-8\">
+    <title>EURUSD Sample Candles</title>
+</head>
+<body>
+    <h1>EURUSD {SAMPLE_SIZE} Bar Sample</h1>
+    {chart_html}
+    <h2>Sample Data</h2>
+    {table_html}
+</body>
+</html>
+"""
+
+    with open("sample_candles.html", "w") as f:
+        f.write(html)
+    print("Created sample_candles.html")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `create_sample_html.py` for exporting a candlestick sample to HTML
- document the new script in the README

## Testing
- `python3 -m py_compile create_sample_html.py`


------
https://chatgpt.com/codex/tasks/task_e_686bd01492ec8325875c2985bf650f30