### PR TITLE
Add equity curve plot to Hover_Breakout_Test

### DIFF
--- a/Hover_Breakout_Test.py
+++ b/Hover_Breakout_Test.py
@@ -1,4 +1,5 @@
 import csv
+import matplotlib.pyplot as plt
 
 # ============================================
 # Hover Breakout Strategy Backtest (No pandas/numpy)
@@ -187,6 +188,19 @@ def _svg_line_chart(values, width=600, height=300, pad=10, max_points=300):
         '</svg>'
     )
 
+
+def plot_equity_curve(curve):
+    """Display equity growth using matplotlib."""
+    plt.figure(figsize=(8, 4))
+    plt.plot(curve, label="Balance")
+    plt.title("Account Balance Over Time")
+    plt.xlabel("Trade")
+    plt.ylabel("Balance")
+    plt.grid(True)
+    plt.tight_layout()
+    plt.legend()
+    plt.show()
+
 def write_html_report(metrics, equity_curve, output_path="hover_backtest_report.html"):
     """Write backtest metrics and account growth to an HTML file."""
     rows_metrics = "\n".join(
@@ -248,7 +262,8 @@ def main():
     for k, v in metrics.items():
         print(f"{k}: {v}")
 
-    # create html report
+    # output visuals
+    plot_equity_curve(equity_curve)
     write_html_report(metrics, equity_curve)
 
 

--- a/README.md
+++ b/README.md
@@ -93,3 +93,21 @@ python3 strategy_test.py --threshold 0.002 --period 10
 
 The program prints metrics such as win rate, risk-reward ratio and expectancy
 along with a simple sensitivity analysis.
+
+## Script: `Hover_Breakout_Test.py`
+
+Runs a breakout backtest on the sample data. The script prints a metrics summary,
+creates `hover_backtest_report.html` with an equity chart and shows a
+`matplotlib` graph of the account balance over time.
+
+Execute it with:
+
+```bash
+python3 Hover_Breakout_Test.py
+```
+
+`matplotlib` is required for the plot:
+
+```bash
+pip install matplotlib
+```


### PR DESCRIPTION
## Summary
- add matplotlib graphing support in `Hover_Breakout_Test.py`
- display/saved account equity curve in CLI run
- document new feature and dependency in README

## Testing
- `python3 Hover_Breakout_Test.py` *(fails: No module named 'matplotlib')*

------
https://chatgpt.com/codex/tasks/task_e_686be856992c8325aa09926c3526475a