### PR TITLE
Fix demo growth by using constant risk

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 # Trading
 
-This repository stores a sample dataset of EUR/USD 30 minute bars and a Python
-scripts for testing different strategies
+This repository stores a sample dataset of EUR/USD 30 minute bars and Python
+scripts for testing different strategies. The demo strategy now risks a fixed
+amount per trade based on the starting equity so account growth remains
+realistic during long simulations.
 
 Package list:
 Pandas, NumPy, MatLab and ReportLab

--- a/hover_breakout_test.py
+++ b/hover_breakout_test.py
@@ -45,6 +45,10 @@ def simulate_strategy(df, lookback, range_threshold_pips, stop_loss_pips,
                       risk_per_trade, initial_equity):
     equity = initial_equity
 
+    # Use a fixed risk amount based on the starting equity so trade size does
+    # not grow uncontrollably as the account balance increases.
+    fixed_risk_amount = initial_equity * risk_per_trade
+
     equity_curve = [equity]
     times = [df['Time'].iloc[0]]
     trades = []
@@ -72,8 +76,9 @@ def simulate_strategy(df, lookback, range_threshold_pips, stop_loss_pips,
                 sl = entry_price - stop_loss_pips * PIP_SIZE if breakout == 'long' else entry_price + stop_loss_pips * PIP_SIZE
                 tp = entry_price + take_profit_pips * PIP_SIZE if breakout == 'long' else entry_price - take_profit_pips * PIP_SIZE
 
-                risk_amount = equity * risk_per_trade
-                lot_size = risk_amount / (stop_loss_pips * PIP_VALUE_PER_LOT)
+                # Position size is based on the fixed risk amount so each trade
+                # risks the same dollar value regardless of account growth.
+                lot_size = fixed_risk_amount / (stop_loss_pips * PIP_VALUE_PER_LOT)
 
                 trade_equity_start = equity
                 result_pips = None


### PR DESCRIPTION
## Summary
- ensure each trade risks the same dollar amount regardless of equity
- document that constant risk sizing is used

## Testing
- `python hover_breakout_test.py` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68702c4b2d688325926e0e0fe488dd73