### PR TITLE
Add main_optimized and update optimizer

### DIFF
--- a/hover_breakout_optimize.py
+++ b/hover_breakout_optimize.py
@@ -4,7 +4,7 @@ from reportlab.lib.pagesizes import letter
 from reportlab.lib.styles import getSampleStyleSheet
 from reportlab.platypus import SimpleDocTemplate, Paragraph, Spacer
 
-from hover_breakout_test import (
+from main_optimized import (
     load_data,
     simulate_strategy,
     calculate_metrics,

--- a/main_optimized.py
+++ b/main_optimized.py
@@ -1,0 +1,44 @@
+"""Optimized main entry point for running the hover breakout strategy.
+
+This script executes the simulation without generating any plots or PDF
+reports. It's intended for quick runs where only the raw metrics are
+needed.
+"""
+
+from hover_breakout_test import (
+    load_data,
+    simulate_strategy,
+    calculate_metrics,
+    LOOKBACK,
+    RANGE_THRESHOLD_PIPS,
+    STOP_LOSS_PIPS,
+    TAKE_PROFIT_PIPS,
+    HOLD_PERIOD,
+    SPREAD_PIPS,
+    RISK_PER_TRADE,
+    INITIAL_EQUITY,
+    BARS_PER_CHECK,
+)
+
+
+def main():
+    """Run the hover breakout strategy without generating graphics."""
+    df = load_data('EURUSD_M1_Data.csv')
+    trade_df, equity_curve, times = simulate_strategy(
+        df,
+        LOOKBACK,
+        RANGE_THRESHOLD_PIPS,
+        STOP_LOSS_PIPS,
+        TAKE_PROFIT_PIPS,
+        HOLD_PERIOD,
+        SPREAD_PIPS,
+        RISK_PER_TRADE,
+        INITIAL_EQUITY,
+        BARS_PER_CHECK,
+    )
+    metrics = calculate_metrics(trade_df, equity_curve)
+    print(metrics)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- add a lightweight `main_optimized.py` that skips generating graphs and PDFs
- point `hover_breakout_optimize.py` to use the new optimized code

## Testing
- `python -m py_compile main_optimized.py hover_breakout_optimize.py hover_breakout_test.py`

------
https://chatgpt.com/codex/tasks/task_e_6870cd8f042083258a7f274cdd532705