### PR TITLE
Improve optimizer ranking

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,16 @@
 # Trading
 
 This repository stores sample datasets of EUR/USD prices and Python scripts for
-testing different strategies.  The main strategy now operates on one minute
-data while checking every 30 candles (30 minutes) for patterns.  When a breakout
-is detected the strategy opens the trade on that same one-minute candle.  Each
-trade risks a fixed amount based on the starting equity so account growth
-remains realistic during long simulations.
+testing different strategies. The main strategy now operates on one minute data
+while checking every 30 candles (30 minutes) for patterns. When a breakout is
+detected the strategy opens the trade on that same one-minute candle. Each trade
+risks a fixed amount based on the starting equity so account growth remains
+realistic during long simulations.
+
+The optimization script explores a grid of parameters and now ranks the results
+by final equity, the total number of trades executed and finally the maximum
+drawdown. This helps surface configurations that are both profitable and
+active.
 
 Package list:
 Pandas, NumPy, MatLab and ReportLab

--- a/hover_breakout_optimize.py
+++ b/hover_breakout_optimize.py
@@ -62,8 +62,12 @@ def generate_opt_report(grid, results, defaults, output_pdf):
         eq = res['Final Equity']
         dd = res['Max Drawdown'] * 100
         exp = res['Expectancy'] * 100
+        trades = res['Total Trades']
         param_str = ', '.join(f"{k}: {v}" for k, v in res['Params'].items())
-        text = f"{i}) Final Equity: {eq:.2f}, Max DD: {dd:.2f}%, Expectancy: {exp:.2f}%"
+        text = (
+            f"{i}) Final Equity: {eq:.2f}, Max DD: {dd:.2f}%," 
+            f" Expectancy: {exp:.2f}%, Trades: {trades}"
+        )
         elements.append(Paragraph(text, styles['Normal']))
         elements.append(Paragraph(param_str, styles['Normal']))
         elements.append(Spacer(1, 6))
@@ -102,6 +106,7 @@ def main():
             'Final Equity': eq_curve[-1],
             'Max Drawdown': metrics['Max Drawdown'],
             'Expectancy': metrics['Expectancy'],
+            'Total Trades': metrics['Total Trades'],
             'Params': {
                 'Lookback': lookback,
                 'Range Threshold (pips)': rng,
@@ -114,7 +119,7 @@ def main():
             }
         })
 
-    results.sort(key=lambda x: (-x['Final Equity'], x['Max Drawdown']))
+    results.sort(key=lambda x: (-x['Final Equity'], -x['Total Trades'], x['Max Drawdown']))
     generate_opt_report(PARAM_GRID, results, DEFAULT_PARAMS, 'Hover_Breakout_Optimization.pdf')
 
 


### PR DESCRIPTION
## Summary
- include `Total Trades` in optimization results
- prefer configs with more trades when sorting
- document new optimization ranking in README

## Testing
- `python -m py_compile hover_breakout_optimize.py hover_breakout_test.py main_optimized.py`

------
https://chatgpt.com/codex/tasks/task_e_68717d828a808325a947f9afa0609a16