### PR TITLE
Add strategy param file and pip PnL column

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,6 @@
 # Trading
+
+This repository provides a simple backtesting template. Place your market
+data in a `data.csv` file alongside the scripts. After running
+`backtester.py`, the resulting `tradelog.csv` and `strategy_params.json`
+can be analysed with `stats_calculator.py` to produce a PDF report.

--- a/backtester.py
+++ b/backtester.py
@@ -1,0 +1,54 @@
+import json
+import pandas as pd
+
+
+def load_market_data(filename: str = 'data.csv') -> pd.DataFrame:
+    """Read price data and return a sorted DataFrame."""
+    df = pd.read_csv(filename, parse_dates=['Time'])
+    df.sort_values('Time', inplace=True)
+    return df
+
+
+def example_strategy(
+    df: pd.DataFrame,
+    sl_pips: int = 20,
+    tp_pips: int = 20,
+) -> list:
+    """Simple placeholder strategy recording trades."""
+    trades = []
+    for i in range(len(df) - 1):
+        open_time = df['Time'].iloc[i]
+        open_price = df['Open'].iloc[i]
+        close_time = df['Time'].iloc[i + 1]
+        close_price = df['Close'].iloc[i + 1]
+        direction = 1
+        pip_diff = (close_price - open_price) * 10000 * direction
+        status = 'partial'
+        if pip_diff >= tp_pips:
+            status = 'tp'
+            pip_diff = tp_pips
+            close_price = open_price + tp_pips / 10000 * direction
+        elif pip_diff <= -sl_pips:
+            status = 'sl'
+            pip_diff = -sl_pips
+            close_price = open_price - sl_pips / 10000 * direction
+        trades.append({
+            'Time Open': open_time,
+            'Open Price': open_price,
+            'Time Close': close_time,
+            'Close Price': close_price,
+            'Pip PnL': pip_diff,
+            'Status': status,
+            'SL': open_price - sl_pips / 10000 * direction,
+            'TP': open_price + tp_pips / 10000 * direction,
+        })
+    pd.DataFrame(trades).to_csv('tradelog.csv', index=False)
+    return trades
+
+
+if __name__ == '__main__':
+    df = load_market_data()
+    params = {'SL Pips': 20, 'TP Pips': 20}
+    example_strategy(df, sl_pips=params['SL Pips'], tp_pips=params['TP Pips'])
+    with open('strategy_params.json', 'w') as f:
+        json.dump(params, f)

--- a/stats_calculator.py
+++ b/stats_calculator.py
@@ -1,0 +1,142 @@
+import json
+import pandas as pd
+import numpy as np
+import matplotlib.pyplot as plt
+from reportlab.lib.pagesizes import letter
+from reportlab.pdfgen import canvas
+
+
+PIP_VALUE = 10  # $10 per pip per standard lot
+
+
+def load_trades(filename: str = 'tradelog.csv') -> pd.DataFrame:
+    """Load trade log from CSV."""
+    df = pd.read_csv(filename, parse_dates=['Time Open', 'Time Close'])
+    df.sort_values('Time Close', inplace=True)
+    return df
+
+
+def load_params(filename: str = 'strategy_params.json') -> dict:
+    """Load strategy parameters from a JSON file if it exists."""
+    try:
+        with open(filename, 'r') as f:
+            return json.load(f)
+    except FileNotFoundError:
+        return {}
+
+
+def calculate_stats(
+    trades: pd.DataFrame,
+    *,
+    starting_equity: float = 10000.0,
+    risk_factor: float = 0.01,
+    leverage: float = 1.0,
+):
+    """Calculate metrics and simulate account equity."""
+    equity = starting_equity
+    equity_curve = [equity]
+    tp_hits = 0
+    sl_hits = 0
+    partial_hits = 0
+    wins = []
+    losses = []
+
+    for _, row in trades.iterrows():
+        pip_diff = row['Pip PnL']
+        status = row['Status']
+        if status == 'tp':
+            tp_hits += 1
+        elif status == 'sl':
+            sl_hits += 1
+        elif status == 'partial':
+            partial_hits += 1
+
+        trade_size = equity * risk_factor
+        lot_size = (trade_size * leverage) / 100000
+        pnl = PIP_VALUE * lot_size * pip_diff
+        equity += pnl
+        equity_curve.append(equity)
+        if pnl >= 0:
+            wins.append(pnl)
+        else:
+            losses.append(pnl)
+
+    total_trades = len(trades)
+    win_rate = len(wins) / total_trades * 100 if total_trades else 0
+    avg_win = np.mean(wins) / starting_equity * 100 if wins else 0
+    avg_loss = abs(np.mean(losses)) / starting_equity * 100 if losses else 0
+
+    curve = np.array(equity_curve)
+    if len(curve) > 1:
+        peaks = np.maximum.accumulate(curve)
+        drawdowns = (peaks - curve) / peaks * 100
+        max_drawdown = drawdowns.max()
+    else:
+        max_drawdown = 0.0
+
+    stats = {
+        'Total Trades': total_trades,
+        'Partial Hits': partial_hits,
+        'TP Hits': tp_hits,
+        'SL Hits': sl_hits,
+        'Win Rate': round(win_rate, 2),
+        'Average Win Size': round(avg_win, 2),
+        'Average Loss Size': round(avg_loss, 2),
+        'Max Drawdown': round(max_drawdown, 2),
+        'Final Equity': round(equity_curve[-1], 2),
+    }
+    return stats, list(zip(trades['Time Close'].tolist(), equity_curve[1:]))
+
+
+def create_pdf_report(
+    stats: dict,
+    equity_curve: list,
+    params: dict,
+    filename: str = 'report.pdf',
+) -> None:
+    """Generate a simple PDF report with equity graph."""
+    # Save equity curve plot
+    if equity_curve:
+        times, values = zip(*equity_curve)
+        plt.figure(figsize=(6, 3))
+        plt.plot(times, values, label='Equity')
+        plt.xlabel('Time')
+        plt.ylabel('Equity')
+        plt.title('Equity Curve')
+        plt.tight_layout()
+        plt.savefig('equity_curve.png')
+        plt.close()
+
+    c = canvas.Canvas(filename, pagesize=letter)
+    width, height = letter
+    y = height - 40
+    c.drawString(40, y, 'Backtest Results')
+    y -= 20
+    for key, val in params.items():
+        c.drawString(40, y, f'{key}: {val}')
+        y -= 15
+    y -= 10
+    for key, val in stats.items():
+        c.drawString(40, y, f'{key}: {val}')
+        y -= 15
+    if equity_curve:
+        y -= 20
+        c.drawImage('equity_curve.png', 40, y - 200, width=500, height=200)
+    c.save()
+
+
+if __name__ == '__main__':
+    trades = load_trades()
+    params = {
+        'Starting Equity': 10000.0,
+        'Risk Factor': 0.01,
+        'Leverage': 1.0,
+    }
+    params.update(load_params())
+    stats, curve = calculate_stats(
+        trades,
+        starting_equity=params['Starting Equity'],
+        risk_factor=params['Risk Factor'],
+        leverage=params['Leverage'],
+    )
+    create_pdf_report(stats, curve, params)


### PR DESCRIPTION
## Summary
- document usage of `strategy_params.json` in README
- write strategy parameters to `strategy_params.json` when running backtester
- rename trade log field to `Pip PnL`
- load parameters in stats calculator for PDF report

## Testing
- `python -m py_compile backtester.py stats_calculator.py`
- `python backtester.py` *(fails: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6884f470cc2c83259954f31ccff7cea8