### PR TITLE
Add Hover Breakout strategy EA

### DIFF
--- a/HoverBreakout.mq5
+++ b/HoverBreakout.mq5
@@ -1,0 +1,151 @@
+#property copyright ""
+#property link      ""
+#property version   "1.00"
+#property strict
+
+#include <Trade/Trade.mqh>
+
+//--- input parameters
+input int    InpRangeBars      = 10;     // Number of bars to define range (excluding breakout bar)
+input double InpRangePoints    = 200;    // Maximum range size in points
+input double InpTPPoints       = 400;    // Take profit distance in points
+input double InpSLPoints       = 200;    // Stop loss distance in points
+input double InpLots           = 0.10;   // Lot size
+input int    InpMaxBarsOpen    = 5;      // Maximum bars to keep position open
+input uint   InpSlippage       = 5;      // Slippage in points
+
+//--- global objects
+CTrade  trade;               // trading object
+
+//+------------------------------------------------------------------+
+//| Helper: detect new bar                                          |
+//+------------------------------------------------------------------+
+bool IsNewBar()
+{
+   static datetime last_bar_time = 0;
+   datetime current_bar_time = iTime(_Symbol, _Period, 0);
+   if(current_bar_time != last_bar_time)
+   {
+      last_bar_time = current_bar_time;
+      return(true);
+   }
+   return(false);
+}
+
+//+------------------------------------------------------------------+
+//| Calculate hover range from past bars                            |
+//| Returns true if bars stayed within specified range               |
+//+------------------------------------------------------------------+
+bool CalcRange(int bars_back, double &range_high, double &range_low)
+{
+   if(bars_back < 2)
+      return(false);
+
+   // initialise with second previous bar because bar1 is the breakout bar
+   range_high = iHigh(_Symbol, _Period, 2);
+   range_low  = iLow(_Symbol,  _Period, 2);
+
+   for(int i = 3; i <= bars_back + 1; i++)
+   {
+      double h = iHigh(_Symbol, _Period, i);
+      double l = iLow(_Symbol,  _Period, i);
+      if(h > range_high) range_high = h;
+      if(l < range_low)  range_low  = l;
+   }
+   return((range_high - range_low) <= InpRangePoints * _Point);
+}
+
+//+------------------------------------------------------------------+
+//| Close open position after a number of bars                       |
+//+------------------------------------------------------------------+
+void CheckForExit()
+{
+   if(!PositionSelect(_Symbol))
+      return;
+
+   datetime open_time = (datetime)PositionGetInteger(POSITION_TIME);
+   int bars_open = iBarShift(_Symbol, _Period, open_time);
+
+   // Close the position if it has been open for too many bars
+   if(bars_open >= InpMaxBarsOpen)
+      trade.PositionClose(_Symbol);
+}
+
+//+------------------------------------------------------------------+
+//| Entry logic: trade on breakout from tight range                 |
+//+------------------------------------------------------------------+
+void CheckForEntry()
+{
+   if(PositionSelect(_Symbol))
+      return; // Only one position at a time
+
+   double high, low;
+   if(!CalcRange(InpRangeBars, high, low))
+      return; // Range condition not met
+
+   double last_close = iClose(_Symbol, _Period, 1);
+
+   trade.SetDeviationInPoints(InpSlippage);
+
+   // Breakout above the range -> buy
+   if(last_close > high)
+   {
+      double price = SymbolInfoDouble(_Symbol, SYMBOL_ASK);
+      double sl = price - InpSLPoints * _Point;
+      double tp = price + InpTPPoints * _Point;
+      trade.Buy(InpLots, _Symbol, price, sl, tp, "HoverBreakout");
+   }
+   // Breakout below the range -> sell
+   else if(last_close < low)
+   {
+      double price = SymbolInfoDouble(_Symbol, SYMBOL_BID);
+      double sl = price + InpSLPoints * _Point;
+      double tp = price - InpTPPoints * _Point;
+      trade.Sell(InpLots, _Symbol, price, sl, tp, "HoverBreakout");
+   }
+}
+
+//+------------------------------------------------------------------+
+//| Expert initialization                                           |
+//+------------------------------------------------------------------+
+int OnInit()
+{
+   return(INIT_SUCCEEDED);
+}
+
+//+------------------------------------------------------------------+
+//| Expert deinitialization                                         |
+//+------------------------------------------------------------------+
+void OnDeinit(const int reason)
+{
+}
+
+//+------------------------------------------------------------------+
+//| Expert tick function                                            |
+//+------------------------------------------------------------------+
+void OnTick()
+{
+   // Only run logic once per new bar
+   if(!IsNewBar())
+      return;
+
+   CheckForExit();   // manage existing position
+   CheckForEntry();  // look for new opportunity
+}
+
+//+------------------------------------------------------------------+
+//+------------------------------------------------------------------+
+//| Custom optimization criterion for Strategy Tester                |
+//| Gives equal weight to trade count, profit and drawdown           |
+//+------------------------------------------------------------------+
+double OnTester()
+{
+   double trades   = TesterStatistics(STAT_TRADES);          // total closed deals
+   double profit   = TesterStatistics(STAT_PROFIT);          // net profit in currency
+   double drawdown = TesterStatistics(STAT_MAX_DD);          // maximal drawdown in currency
+
+   // maximize trades and profit while minimizing drawdown
+   return (trades/3.0) + (profit/3.0) - (drawdown/3.0);
+}
+
+//+------------------------------------------------------------------+


### PR DESCRIPTION
## Summary
- add Hover Breakout Expert Advisor implementing range breakout logic with configurable TP/SL
- add custom optimization criterion balancing trade count, profit, and drawdown
- fix custom optimization criterion to use available drawdown statistic

## Testing
- `mql5compiler HoverBreakout.mq5` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688e8ca0761c83258fdef7adfc0f98df