### PR TITLE
Add random direction test bot

### DIFF
--- a/RandomBot.mq5
+++ b/RandomBot.mq5
@@ -1,0 +1,62 @@
+#property copyright "MJ Kruger"
+#property link      "https://github.com/Maarten-Kruger/Trading"
+#property version   "1.00"
+#property strict
+
+#include <Trade/Trade.mqh>
+
+//--- input parameters
+input double InpLots      = 0.10;  // Lot size
+input uint   InpSlippage  = 5;     // Slippage in points
+
+CTrade  trade;               // trading object
+
+//+------------------------------------------------------------------+
+//| Helper: detect new bar                                          |
+//+------------------------------------------------------------------+
+bool IsNewBar()
+  {
+   static datetime last_bar_time = 0;
+   datetime current_bar_time = iTime(_Symbol, _Period, 0);
+   if(current_bar_time != last_bar_time)
+     {
+      last_bar_time = current_bar_time;
+      return(true);
+     }
+   return(false);
+  }
+
+//+------------------------------------------------------------------+
+//| Expert initialization                                           |
+//+------------------------------------------------------------------+
+int OnInit()
+  {
+   MathSrand((uint)TimeLocal());
+   return(INIT_SUCCEEDED);
+  }
+
+//+------------------------------------------------------------------+
+//| Expert deinitialization                                         |
+//+------------------------------------------------------------------+
+void OnDeinit(const int reason)
+  {
+  }
+
+//+------------------------------------------------------------------+
+//| Expert tick function                                            |
+//+------------------------------------------------------------------+
+void OnTick()
+  {
+   if(!IsNewBar())
+      return;
+
+   trade.SetDeviationInPoints(InpSlippage);
+
+   if(PositionSelect(_Symbol))
+      trade.PositionClose(_Symbol);
+
+   if(MathRand() % 2 == 0)
+      trade.Buy(InpLots, _Symbol);
+   else
+      trade.Sell(InpLots, _Symbol);
+  }


### PR DESCRIPTION
## Summary
- add `RandomBot` expert advisor that opens a trade every new minute bar in a randomly selected direction

## Testing
- `metaeditor64 -compile RandomBot.mq5` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_689378d3c24c83258b521ffbf932d96e