### PR TITLE
Allow multiple simultaneous trades

### DIFF
--- a/1.0 HoverBreakout.mq5
+++ b/1.0 HoverBreakout.mq5
@@ -62,15 +62,26 @@ bool CalcRange(int bars_back, double &range_high, double &range_low)
 //+------------------------------------------------------------------+
 void CheckForExit()
   {
-   if(!PositionSelect(_Symbol))
-      return;
+// Iterate through all open positions and close those that have been
+// open for longer than the allowed number of bars (InpMaxBarsOpen).
+   for(int i = PositionsTotal() - 1; i >= 0; i--)
+     {
+      if(!PositionSelectByIndex(i))
+         continue;
 
-   datetime open_time = (datetime)PositionGetInteger(POSITION_TIME);
-   int bars_open = iBarShift(_Symbol, _Period, open_time);
+      string symbol = PositionGetString(POSITION_SYMBOL);
+      if(symbol != _Symbol)
+         continue;
 
-// Close the position if it has been open for too many bars
-   if(bars_open >= InpMaxBarsOpen)
-      trade.PositionClose(_Symbol);
+      datetime open_time = (datetime)PositionGetInteger(POSITION_TIME);
+      int bars_open = iBarShift(_Symbol, _Period, open_time);
+
+      if(bars_open >= InpMaxBarsOpen)
+        {
+         ulong ticket = (ulong)PositionGetInteger(POSITION_TICKET);
+         trade.PositionClose(ticket);
+        }
+     }
   }
 
 //+------------------------------------------------------------------+
@@ -78,9 +89,6 @@ void CheckForExit()
 //+------------------------------------------------------------------+
 void CheckForEntry()
   {
-   if(PositionSelect(_Symbol))
-      return; // Only one position at a time
-
    double high, low;
    if(!CalcRange(InpRangeBars, high, low))
       return; // Range condition not met

--- a/1.1 HoverBreakout.mq5
+++ b/1.1 HoverBreakout.mq5
@@ -62,15 +62,26 @@ bool CalcRange(int bars_back, double &range_high, double &range_low)
 //+------------------------------------------------------------------+
 void CheckForExit()
   {
-   if(!PositionSelect(_Symbol))
-      return;
+// Iterate through all open positions and close those that exceed the
+// maximum number of bars specified in InpMaxBarsOpen.
+   for(int i = PositionsTotal() - 1; i >= 0; i--)
+     {
+      if(!PositionSelectByIndex(i))
+         continue;
 
-   datetime open_time = (datetime)PositionGetInteger(POSITION_TIME);
-   int bars_open = iBarShift(_Symbol, _Period, open_time);
+      string symbol = PositionGetString(POSITION_SYMBOL);
+      if(symbol != _Symbol)
+         continue;
 
-// Close the position if it has been open for too many bars
-   if(bars_open >= InpMaxBarsOpen)
-      trade.PositionClose(_Symbol);
+      datetime open_time = (datetime)PositionGetInteger(POSITION_TIME);
+      int bars_open = iBarShift(_Symbol, _Period, open_time);
+
+      if(bars_open >= InpMaxBarsOpen)
+        {
+         ulong ticket = (ulong)PositionGetInteger(POSITION_TICKET);
+         trade.PositionClose(ticket);
+        }
+     }
   }
 
 //+------------------------------------------------------------------+
@@ -78,9 +89,6 @@ void CheckForExit()
 //+------------------------------------------------------------------+
 void CheckForEntry()
   {
-   if(PositionSelect(_Symbol))
-      return; // Only one position at a time
-
    double high, low;
    if(!CalcRange(InpRangeBars, high, low))
       return; // Range condition not met


### PR DESCRIPTION
## Summary
- allow HoverBreakout EA to open multiple positions at once
- close each position individually after it exceeds configured bar duration

## Testing
- `make test` *(fails: No rule to make target 'test')*


------
https://chatgpt.com/codex/tasks/task_e_689514c578e48325abebf95c69ff0750