### PR TITLE
Allow multiple concurrent trades in Grouped Volatility EA

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,10 @@
 
 Collection of MetaTrader 5 Expert Advisors.
 
+## Grouped Volatility
+
+`1.2 GroupedVolatility.mq5` now evaluates candle patterns even when other
+positions remain open, allowing multiple trades to run concurrently when the
+setup reappears on new bars.
+
 


### PR DESCRIPTION
## Summary
- Remove `IsNewBar` helper and track last trade bar directly
- Continue evaluating candle patterns even with existing positions to allow stacking trades
- Document multiple-trade behaviour in README

## Testing
- `python -m unittest`

------
https://chatgpt.com/codex/tasks/task_e_689f301c2d508325a063992a829b08c1