### PR TITLE
Add custom optimization objective for HoverBreakout

### DIFF
--- a/1.3 HoverBreakout.mq5
+++ b/1.3 HoverBreakout.mq5
@@ -175,3 +175,40 @@ void OnTick()
    CheckForEntry();  // look for new opportunity
   }
 
+//+------------------------------------------------------------------+
+//| Custom optimization criterion                                    |
+//| y = T*Wt + P*Wp - D*Wd                                           |
+//|   T : trade density = total trades / total bars                  |
+//|   P : monthly profit = total profit / months                     |
+//|   D : relative drawdown percent from tester statistics           |
+//+------------------------------------------------------------------+
+double OnTester()
+  {
+   // Retrieve base statistics from the strategy tester
+   double trades      = TesterStatistics(STAT_TRADES);                 // total number of trades
+   double bars        = (double)Bars(_Symbol, PERIOD_CURRENT);         // total number of bars in test
+   double profit      = TesterStatistics(STAT_PROFIT);                 // total net profit
+   double months      = (double)Bars(_Symbol, PERIOD_MN1);             // test length in months
+   double drawdownPct = TesterStatistics(STAT_EQUITY_DDREL_PERCENT);   // relative drawdown
+
+   double tradeDensity = 0.0;
+   if(bars > 0.0)
+      tradeDensity = trades / bars;
+
+   double monthlyProfit = 0.0;
+   if(months > 0.0)
+      monthlyProfit = profit / months;
+
+   // Normalise weights so they sum to 1.0 even if inputs don't add to 100
+   double weightSum = InpWt + InpWp + InpWd;
+   if(weightSum <= 0.0)
+      weightSum = 1.0;
+   double wt = InpWt / weightSum;
+   double wp = InpWp / weightSum;
+   double wd = InpWd / weightSum;
+
+   // Objective value to maximise during optimisation
+   double score = tradeDensity * wt + monthlyProfit * wp - drawdownPct * wd;
+   return(score);
+  }
+


### PR DESCRIPTION
## Summary
- add weighted trade density, monthly profit, and drawdown objective function for HoverBreakout
- derive total bars and months via `Bars()` to avoid invalid statistics identifiers

## Testing
- `make test` (fails: No rule to make target 'test')

------
https://chatgpt.com/codex/tasks/task_e_68a5c2602ffc832596b4fcfd7f48a02a