### PR TITLE
Ensure volatility bot uses open-close body for candle size

### DIFF
--- a/1.0 Volatility.mq5
+++ b/1.0 Volatility.mq5
@@ -111,12 +111,15 @@ bool CheckLargeCandles(const MqlRates &rates_array[], int rates_count, bool &isB
       return(false);
 
    double pip = PipValue();
-   double threshold = InpBodyThresholdPips * pip;
+   if(pip <= 0.0)
+      return(false);
 
    for(int i = 0; i < rates_count; ++i)
    {
-      double body = MathAbs(rates_array[i].close - rates_array[i].open);
-      if(body < threshold)
+      double body_points = MathAbs(rates_array[i].close - rates_array[i].open);
+      double body_pips   = body_points / pip;
+
+      if(body_pips < InpBodyThresholdPips)
          return(false);
    }
 


### PR DESCRIPTION
## Summary
- guard against invalid pip sizes when evaluating volatility candles
- measure candle bodies in pips using the open-close distance to enforce the large-candle threshold

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ceee8b66c88325a6cd3fabc6332880