### PR TITLE
Fix regression slope direction

### DIFF
--- a/1.1 Momentum Bot.mq5
+++ b/1.1 Momentum Bot.mq5
@@ -224,7 +224,7 @@ double CalculateLinearRegressionSlope(const int period,const int shift)
 
    for(int i=0;i<period;i++)
      {
-      double x = (double)i;
+      double x = (double)(period - 1 - i);
       double y = priceBuffer[i];
       sumX  += x;
       sumY  += y;


### PR DESCRIPTION
## Summary
- treat newer bars as higher x-values when calculating the linear regression slope so the sign reflects price direction

## Testing
- python - <<'PY'


------
https://chatgpt.com/codex/tasks/task_e_68e4439e77088325947f7fc0caa12a7a